### PR TITLE
Update bouncy castle

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcprov-jdk15on</artifactId>
-            <version>1.52</version>
+            <version>1.65</version>
         </dependency>
 
         <!-- Compile dependencies -->
@@ -88,8 +88,8 @@
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.3</version>
                 <configuration>
-                    <source>1.7</source>
-                    <target>1.7</target>
+                    <source>1.8</source>
+                    <target>1.8</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -1,14 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    <groupId>com.github.davidcarboni</groupId>
-    <artifactId>cryptolite</artifactId>
-    <version>1.3.4-SNAPSHOT</version>
+    <groupId>com.github.onsdigital</groupId>
+    <artifactId>dp-cryptolite-java</artifactId>
+    <version>1.4.0-SNAPSHOT</version>
     <packaging>jar</packaging>
-    <name>Cryptolite</name>
-    <description>Good, clean, "right" cryptography, bypassing all the options. See:
-        http://www.daemonology.net/blog/2009-06-11-cryptographic-right-answers.html
-    </description>
-    <url>https://github.com/davidcarboni/Cryptolite</url>
+    <name>dp-cryptolite-java</name>
+    <description>Fork of davidcarboni/cryptolite</description>
+    <url>https://github.com/ONSdigital/dp-cryptolite-java</url>
 
     <licenses>
         <license>
@@ -18,31 +16,6 @@
             <comments>A business-friendly OSS license</comments>
         </license>
     </licenses>
-
-    <organization>
-        <name>Carboni</name>
-        <url>https://github.com/carboni/</url>
-    </organization>
-
-    <scm>
-        <url>https://github.com/davidcarboni/Cryptolite</url>
-        <connection>scm:git:git://github.com/davidcarboni/Cryptolite.git</connection>
-        <developerConnection>scm:git:git@github.com:davidcarboni/Cryptolite.git</developerConnection>
-        <tag>HEAD</tag>
-    </scm>
-
-    <distributionManagement>
-        <snapshotRepository>
-            <id>sonatype-nexus-snapshots</id>
-            <name>Sonatype Nexus snapshot repository</name>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
-        </snapshotRepository>
-        <repository>
-            <id>sonatype-nexus-staging</id>
-            <name>Sonatype Nexus release repository</name>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
-    </distributionManagement>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -226,16 +199,5 @@
         </profile>
 
     </profiles>
-
-    <developers>
-        <developer>
-            <id>david</id>
-            <name>David Carboni</name>
-            <email>david@carboni.io</email>
-            <organization>Carboni</organization>
-            <organizationUrl>https://github.com/carboni</organizationUrl>
-            <url>https://github.com/davidcarboni</url>
-        </developer>
-    </developers>
 
 </project>


### PR DESCRIPTION
Update bouncy castle (bcprov-jdk15on) to version 1.65.
This required forking this repository.
This PR also cleans up non-essential project info from the POM.

A tag (`v1.4.0`) will be taken on approval and used in zebedee as a dependency.

Anyone but me can review. Suggest @daiLlew or @janderson2 