### PR TITLE
Release 1.5.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.onsdigital</groupId>
     <artifactId>dp-cryptolite-java</artifactId>
-    <version>1.4.1-SNAPSHOT</version>
+    <version>1.5.1</version>
     <packaging>jar</packaging>
     <name>dp-cryptolite-java</name>
     <description>Fork of davidcarboni/cryptolite</description>

--- a/pom.xml
+++ b/pom.xml
@@ -2,7 +2,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>com.github.onsdigital</groupId>
     <artifactId>dp-cryptolite-java</artifactId>
-    <version>1.5.1</version>
+    <version>1.5.2-SNAPSHOT</version>
     <packaging>jar</packaging>
     <name>dp-cryptolite-java</name>
     <description>Fork of davidcarboni/cryptolite</description>


### PR DESCRIPTION
To keep git tags and maven versions in sync.
https://github.com/ONSdigital/dp-cryptolite-java/commit/fb5d4ce66350216f012927f71016e9b7686233f8 will be tagged as v1.5.1
